### PR TITLE
Switch bot pushes to GitHub App token for ruleset bypass

### DIFF
--- a/.github/workflows/weekly-scan.yml
+++ b/.github/workflows/weekly-scan.yml
@@ -401,7 +401,19 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
+      # Mint a scoped token from the Kilowott Repo Health Bot App so
+      # the bot push passes the ruleset bypass (github-actions[bot]
+      # isn't a valid bypass actor on this tier).
+      - name: Generate App token for pushing
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Download discovery artifact
         uses: actions/download-artifact@v4
@@ -475,10 +487,20 @@ jobs:
     permissions:
       contents: write   # Phase 3c: commit reports/<repo>/history.json updates
     steps:
+      # Same App-token pattern as aggregate — this job also pushes
+      # history updates to main and needs the ruleset bypass.
+      - name: Generate App token for pushing
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 1
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Pull latest
         run: git pull --ff-only origin main


### PR DESCRIPTION
Rescan has been blocked since the ruleset migration because github-actions[bot] can't be added to bypass. This PR switches the workflow to mint an App-scoped token at runtime (Kilowott-Repo-Health-Bot, org-owned) which IS a valid bypass actor.

After merge:
- Manual rescan trigger to validate the fix
- 5b rescan outcome visible on live dashboard
- Unblocks 5c and 5d auto-fix work

## Sneha — please approve
One-step workflow edit + secret references. Needs your click.