### PR TITLE
Phase 5c: scheduled auto-fix PRs (canary kw-wp-scaffold)

### DIFF
--- a/.github/workflows/autofix-monthly.yml
+++ b/.github/workflows/autofix-monthly.yml
@@ -1,0 +1,190 @@
+name: Monthly auto-fix PRs
+
+# Runs on the 1st of each month at 04:00 UTC. Manual dispatch
+# supports a dry_run flag for safe validation without side effects.
+on:
+  schedule:
+    - cron: '0 4 1 * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run — log intent without pushing branches or opening PRs'
+        required: false
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+
+permissions:
+  contents: read   # repo-health read — everything else escalates via App token
+
+concurrency:
+  group: autofix-monthly
+  cancel-in-progress: false
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Discover — mirrors the weekly-scan discovery so autofix sees the current
+  # set of org repos plus targets.yml overrides (including the `autofix` flag).
+  # ---------------------------------------------------------------------------
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      has_eligible: ${{ steps.emit.outputs.has_eligible }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # ubuntu-latest ships the Python kislyuk/yq (different flags). We want
+      # the Go mikefarah/yq that supports `-o=json`. Install explicitly.
+      - name: Install yq (mikefarah)
+        run: |
+          sudo wget -qO /usr/local/bin/yq \
+            https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+          yq --version
+
+      - name: Convert targets.yml to JSON
+        run: yq -o=json targets.yml > targets.json
+
+      - name: Auto-discover org repos
+        env:
+          GITHUB_TOKEN: ${{ secrets.ORG_SCAN_TOKEN }}
+          ORG: Kilowott-labs
+          OVERRIDES: targets.json
+          OUTPUT: discovered-targets.json
+        run: node scripts/discover.js
+
+      - name: Summarise eligibility
+        id: emit
+        run: |
+          set -euo pipefail
+          ELIGIBLE=$(jq '[.repos[] | select(.autofix.phpcs == true)] | length' discovered-targets.json)
+          echo "Eligible for phpcbf autofix: $ELIGIBLE repo(s)"
+          jq -r '.repos[] | select(.autofix.phpcs == true) | "  + " + .name' discovered-targets.json
+          if [ "$ELIGIBLE" -gt 0 ]; then
+            echo "has_eligible=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_eligible=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload discovery artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: discovered-targets
+          path: discovered-targets.json
+          retention-days: 30
+
+  # ---------------------------------------------------------------------------
+  # Flow A — phpcbf auto-fix PRs into target repos.
+  # ---------------------------------------------------------------------------
+  autofix-phpcbf:
+    needs: discover
+    if: needs.discover.outputs.has_eligible == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      # App token has bypass on the ruleset + write access to all
+      # repos the App is installed on. Used for both the target repo
+      # clones and PR creation.
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: Kilowott-labs
+
+      - name: Checkout repo-health
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Download discovered targets
+        uses: actions/download-artifact@v4
+        with:
+          name: discovered-targets
+          path: .
+
+      - name: Set up PHP + phpcbf
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          tools: composer, phpcs, phpcbf
+          coverage: none
+
+      - name: Install WPCS + related coding standards
+        run: |
+          set -euo pipefail
+          # Composer 2.2+ requires the phpcs-installer plugin to be
+          # allowlisted — same pattern as Phase 2's PHPCS setup.
+          composer global config --no-plugins allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
+          composer global require --no-interaction \
+            "squizlabs/php_codesniffer=*" \
+            "wp-coding-standards/wpcs=*" \
+            "phpcompatibility/phpcompatibility-wp=*" \
+            "automattic/vipwpcs=*" \
+            "dealerdirect/phpcodesniffer-composer-installer=*"
+          export PATH="$HOME/.composer/vendor/bin:$PATH"
+          echo "$HOME/.composer/vendor/bin" >> "$GITHUB_PATH"
+          phpcs -i
+          if ! phpcs -i | grep -q "WordPress"; then
+            echo "::error::WordPress standard did not register. Fix composer install log above."
+            exit 1
+          fi
+
+      - name: Run phpcbf autofix
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          TARGETS_JSON: discovered-targets.json
+          PHPCBF_STANDARD: WordPress
+          ORG: Kilowott-labs
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: node scripts/autofix-phpcbf.js
+
+  # ---------------------------------------------------------------------------
+  # Flow B — false-positive allowlist PRs into repo-health itself.
+  # ---------------------------------------------------------------------------
+  autofix-allowlist:
+    needs: discover
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: Kilowott-labs
+
+      - name: Checkout repo-health
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Download discovered targets
+        uses: actions/download-artifact@v4
+        with:
+          name: discovered-targets
+          path: .
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run allowlist autofix
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+          TARGETS_JSON: discovered-targets.json
+          REPORTS_DIR: reports
+          ORG: Kilowott-labs
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: node scripts/autofix-allowlist.js

--- a/scripts/aggregate.js
+++ b/scripts/aggregate.js
@@ -21,6 +21,7 @@
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
+const { fingerprint: findingFingerprint } = require('./lib/fingerprint');
 
 const TARGETS_JSON = process.env.TARGETS_JSON || 'targets.json';
 const ORG = process.env.ORG || 'Kilowott-labs';
@@ -88,16 +89,10 @@ function computeScannerCounts(findings) {
   return counts;
 }
 
-// Same hash shape as file-issues.js — keep IDs consistent across both outputs.
-function findingFingerprint(f) {
-  const parts = [
-    f.Source || '',
-    f.RuleID || '',
-    f.File || '',
-    String(f.StartLine || 0),
-  ].join('|');
-  return 'F-' + crypto.createHash('sha256').update(parts).digest('hex').slice(0, 8);
-}
+// Fingerprint moved to scripts/lib/fingerprint.js — imported above as
+// `findingFingerprint`. Previously this was a second implementation using
+// SHA-256 (file-issues.js used SHA-1) which produced different IDs for the
+// same finding. Now both read from the single shared module.
 
 function ageDays(isoOrDate) {
   if (!isoOrDate) return 0;

--- a/scripts/autofix-allowlist.js
+++ b/scripts/autofix-allowlist.js
@@ -1,0 +1,359 @@
+#!/usr/bin/env node
+/**
+ * Phase 5c flow B — false-positive → allowlist PR.
+ *
+ * For each target repo, query health-check issues labeled
+ * `false-positive`. For each matching issue:
+ *   - Parse finding IDs (F-xxxxxxxx) from the issue body.
+ *   - Look up each finding in reports/<repo>/latest.json.
+ *   - Generate a config edit in repo-health itself:
+ *       gitleaks   → .gitleaks.toml    (allowlist paths)
+ *       phpcs      → configs/phpcs-ruleset.xml  (exclude-pattern)
+ *       semgrep    → configs/semgrep.yml        (paths:exclude)
+ *       npm-audit  → SKIPPED (dependency CVEs need manual triage)
+ *       osv        → SKIPPED (same reason)
+ *   - Batch all edits into a single monthly PR against repo-health.
+ *
+ * Idempotency: branch name is `repo-health/allowlist-update-<YYYY-MM>`
+ * — re-runs in the same month are no-ops if the branch already
+ * exists on origin.
+ *
+ * Environment:
+ *   GH_TOKEN       App token (write access to repo-health)
+ *   DRY_RUN        "true" to log intent without pushing / opening PRs
+ *   TARGETS_JSON   path to discovered-targets.json
+ *   REPORTS_DIR    path to reports/ (default 'reports')
+ *   ORG            e.g. "Kilowott-labs"
+ *
+ * Exit code: 0 on any outcome. Best-effort tool.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const { fingerprint } = require('./lib/fingerprint');
+
+const TOKEN = process.env.GH_TOKEN || process.env.GITHUB_TOKEN || '';
+const DRY_RUN = String(process.env.DRY_RUN || '').toLowerCase() === 'true';
+const TARGETS_JSON = process.env.TARGETS_JSON || 'discovered-targets.json';
+const REPORTS_DIR = process.env.REPORTS_DIR || 'reports';
+const ORG = process.env.ORG || 'Kilowott-labs';
+
+const MONTH = new Date().toISOString().slice(0, 7);
+const BRANCH = `repo-health/allowlist-update-${MONTH}`;
+const BRANCH_PATTERN = 'repo-health/allowlist-update-';
+
+if (!TOKEN) {
+  console.error('GH_TOKEN / GITHUB_TOKEN required.');
+  process.exit(1);
+}
+
+function log(line) {
+  console.log(`[autofix-allowlist] ${line}`);
+}
+
+function gh(args) {
+  return execFileSync('gh', args, {
+    encoding: 'utf8',
+    env: { ...process.env, GH_TOKEN: TOKEN, GITHUB_TOKEN: TOKEN },
+  });
+}
+
+// Array-form git runner — avoids shell interpretation of dynamic strings
+// (commit messages, PR bodies) that would otherwise need escaping.
+function git(args, opts = {}) {
+  return execFileSync('git', args, {
+    stdio: 'inherit', encoding: 'utf8', ...opts,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Discover false-positive issues across all target repos
+// ---------------------------------------------------------------------------
+function loadTargets() {
+  const raw = JSON.parse(fs.readFileSync(TARGETS_JSON, 'utf8'));
+  return raw.repos || [];
+}
+
+function findFalsePositiveIssues(repoName) {
+  try {
+    const body = gh([
+      'issue', 'list',
+      '--repo', `${ORG}/${repoName}`,
+      '--label', 'health-check,false-positive',
+      '--state', 'open',
+      '--json', 'number,title,body,url,labels',
+      '--limit', '50',
+    ]);
+    return JSON.parse(body || '[]');
+  } catch (err) {
+    log(`${repoName}: issue list failed (${err.message.slice(0, 120)})`);
+    return [];
+  }
+}
+
+// Finding IDs look like `F-abc12345` (8 hex chars). Extract from issue body.
+function extractFindingIds(issueBody) {
+  const re = /\bF-[0-9a-f]{8}\b/g;
+  return Array.from(new Set((issueBody || '').match(re) || []));
+}
+
+function loadLatestFindings(repoName) {
+  const p = path.join(REPORTS_DIR, repoName, 'latest.json');
+  if (!fs.existsSync(p)) return [];
+  try {
+    const data = JSON.parse(fs.readFileSync(p, 'utf8'));
+    return Array.isArray(data) ? data : [];
+  } catch {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Config editors — one per scanner type
+// ---------------------------------------------------------------------------
+function addGitleaksAllowlist(configPath, file, ruleId, sourceIssue) {
+  const contents = fs.existsSync(configPath) ? fs.readFileSync(configPath, 'utf8') : '';
+  const tag = `# allowlist: ${file} (${ruleId}) — from issue ${sourceIssue}`;
+  if (contents.includes(tag)) return { changed: false, reason: 'already allowlisted' };
+
+  // Append a paths entry. Gitleaks TOML allowlist supports `paths = [ "...regex..." ]`
+  // at the top level. Escape `.` and `/` for regex safety.
+  const escaped = file.replace(/[.+^$()|[\]{}\\]/g, '\\$&');
+  const block =
+    `\n${tag}\n` +
+    `[[allowlists]]\n` +
+    `description = "false-positive allowlist (auto-generated)"\n` +
+    `paths = ["^${escaped}$"]\n`;
+
+  fs.appendFileSync(configPath, block);
+  return { changed: true };
+}
+
+function addPhpcsExclude(configPath, file, ruleId, sourceIssue) {
+  if (!fs.existsSync(configPath)) return { changed: false, reason: 'config missing' };
+  const contents = fs.readFileSync(configPath, 'utf8');
+  const tag = `<!-- allowlist: ${file} (${ruleId}) — from issue ${sourceIssue} -->`;
+  if (contents.includes(tag)) return { changed: false, reason: 'already allowlisted' };
+
+  const block = `  ${tag}\n  <exclude-pattern>${file}</exclude-pattern>\n`;
+  // Insert before the closing </ruleset> tag.
+  if (!contents.includes('</ruleset>')) {
+    return { changed: false, reason: '</ruleset> tag not found' };
+  }
+  const updated = contents.replace('</ruleset>', `${block}</ruleset>`);
+  fs.writeFileSync(configPath, updated);
+  return { changed: true };
+}
+
+function addSemgrepExclude(configPath, file, ruleId, sourceIssue) {
+  if (!fs.existsSync(configPath)) return { changed: false, reason: 'config missing' };
+  const contents = fs.readFileSync(configPath, 'utf8');
+  const tag = `# allowlist: ${file} (${ruleId}) — from issue ${sourceIssue}`;
+  if (contents.includes(tag)) return { changed: false, reason: 'already allowlisted' };
+
+  // Append a paths.exclude entry. If the file has no paths: block,
+  // add one. Simple append — semgrep config is YAML but we avoid
+  // parsing (no dep); tag+newline is safe to append.
+  const block = `\n${tag}\npaths:\n  exclude:\n    - "${file}"\n`;
+  fs.appendFileSync(configPath, block);
+  return { changed: true };
+}
+
+const SCANNER_HANDLERS = {
+  gitleaks: (file, rule, issue) => addGitleaksAllowlist('.gitleaks.toml', file, rule, issue),
+  phpcs:    (file, rule, issue) => addPhpcsExclude('configs/phpcs-ruleset.xml', file, rule, issue),
+  semgrep:  (file, rule, issue) => addSemgrepExclude('configs/semgrep.yml', file, rule, issue),
+};
+
+// ---------------------------------------------------------------------------
+// Idempotency + push + PR
+// ---------------------------------------------------------------------------
+function existingOpenPr() {
+  try {
+    const body = gh([
+      'pr', 'list',
+      '--repo', `${ORG}/repo-health`,
+      '--state', 'open',
+      '--search', `head:${BRANCH_PATTERN} in:title [autofix-allowlist]`,
+      '--json', 'number,headRefName,url',
+    ]);
+    const arr = JSON.parse(body || '[]');
+    return arr.find(pr => String(pr.headRefName || '').startsWith(BRANCH_PATTERN)) || null;
+  } catch {
+    return null;
+  }
+}
+
+function existingBranch() {
+  try {
+    gh(['api', `/repos/${ORG}/repo-health/branches/${encodeURIComponent(BRANCH)}`]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function commitAndPushSelf(appliedCount) {
+  const msg =
+    `chore(autofix-allowlist): batch config updates ${MONTH}\n\n` +
+    `Auto-generated from ${appliedCount} false-positive label(s) across\n` +
+    `target repos' health-check issues.\n\n` +
+    `Review before merging — these entries silence findings permanently.`;
+  git(['config', 'user.name',  'kilowott-repo-health-bot[bot]']);
+  git(['config', 'user.email', 'kilowott-repo-health-bot[bot]@users.noreply.github.com']);
+  git(['checkout', '-b', BRANCH]);
+  git(['add', '-A']);
+  git(['commit', '-m', msg]);
+  git(['push', 'origin', BRANCH]);
+}
+
+function openSelfPr(applied) {
+  const scanners = Array.from(new Set(applied.map(a => a.scanner)));
+  const repos = Array.from(new Set(applied.map(a => a.repo)));
+  const body =
+`Batch allowlist updates from false-positive-labeled health-check issues.
+
+## Applied entries
+${applied.map(a => `- \`${a.scanner}\` · \`${a.file}\` · ${a.rule} (from ${ORG}/${a.repo}#${a.issueNumber})`).join('\n')}
+
+## Scanners touched
+${scanners.map(s => `- ${s}`).join('\n')}
+
+## Repos sourced from
+${repos.map(r => `- \`${r}\``).join('\n')}
+
+## Review
+Each entry silences a finding permanently on future scans. If any
+allowlist entry looks wrong, remove it from this PR before merging —
+the next scan will re-surface the finding and the label can be
+cleared on the source issue.
+
+## Note
+\`npm-audit\` and \`osv\` findings are NOT auto-allowlisted — dependency
+CVEs require human triage (upgrade, audit-resolve, or suppress with
+context).
+
+Run: ${process.env.RUN_URL || 'local run'}
+`;
+  return gh([
+    'pr', 'create',
+    '--repo', `${ORG}/repo-health`,
+    '--base', 'main',
+    '--head', BRANCH,
+    '--title', `[autofix-allowlist] ${applied.length} entries · ${MONTH}`,
+    '--body', body,
+    '--label', 'autofix',
+    '--label', 'allowlist',
+  ]).trim();
+}
+
+function commentOnSourceIssue(repo, issueNumber, prUrl) {
+  try {
+    gh([
+      'issue', 'comment', String(issueNumber),
+      '--repo', `${ORG}/${repo}`,
+      '--body', `Allowlist PR opened: ${prUrl}\n\nWhen merged, the finding(s) referenced here will no longer be reported on future scans.`,
+    ]);
+  } catch (err) {
+    log(`${repo}#${issueNumber}: comment failed (${err.message.slice(0, 120)})`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+(function main() {
+  log(`month: ${MONTH}  dry_run: ${DRY_RUN}`);
+
+  // Short-circuit: if a PR already exists or the branch exists on
+  // origin, don't do anything this month.
+  const existing = existingOpenPr();
+  if (existing) {
+    log(`open allowlist PR already exists: #${existing.number} — skipping`);
+    process.exit(0);
+  }
+  if (existingBranch()) {
+    log(`branch ${BRANCH} already exists on remote — skipping`);
+    process.exit(0);
+  }
+
+  const targets = loadTargets();
+  const applied = [];
+  const skipped = [];
+
+  for (const target of targets) {
+    const repoName = target.name;
+    const issues = findFalsePositiveIssues(repoName);
+    if (issues.length === 0) continue;
+
+    log(`${repoName}: ${issues.length} false-positive issue(s) found`);
+    const findings = loadLatestFindings(repoName);
+    // IDs are derived via the shared fingerprint module — same algorithm
+    // that file-issues.js used to write the F-xxxxxxxx into the issue body
+    // we're now parsing. Mismatch would mean no finding ever resolves.
+    const findingById = new Map(findings.map(f => [fingerprint(f), f]));
+
+    for (const issue of issues) {
+      const ids = extractFindingIds(issue.body);
+      if (ids.length === 0) {
+        skipped.push({ repo: repoName, issue: issue.number, reason: 'no F- IDs in body' });
+        continue;
+      }
+      for (const id of ids) {
+        const finding = findingById.get(id);
+        if (!finding) {
+          skipped.push({ repo: repoName, issue: issue.number, id, reason: 'finding not in latest.json' });
+          continue;
+        }
+        const scanner = String(finding.Source || '').toLowerCase();
+        const handler = SCANNER_HANDLERS[scanner];
+        if (!handler) {
+          skipped.push({ repo: repoName, issue: issue.number, id, scanner, reason: 'scanner not auto-allowlistable' });
+          continue;
+        }
+        const res = handler(finding.File || '', finding.RuleID || '', `${ORG}/${repoName}#${issue.number}`);
+        if (res.changed) {
+          applied.push({
+            repo: repoName,
+            issueNumber: issue.number,
+            issueUrl: issue.url,
+            id,
+            scanner,
+            file: finding.File,
+            rule: finding.RuleID,
+          });
+          log(`  applied: ${id} (${scanner}) → ${finding.File}`);
+        } else {
+          skipped.push({ repo: repoName, issue: issue.number, id, scanner, reason: res.reason });
+        }
+      }
+    }
+  }
+
+  log(`applied: ${applied.length}   skipped: ${skipped.length}`);
+  if (skipped.length > 0) log('skipped: ' + JSON.stringify(skipped));
+
+  if (applied.length === 0) {
+    log('no applicable allowlist edits — nothing to PR.');
+    process.exit(0);
+  }
+
+  if (DRY_RUN) {
+    log(`DRY RUN — would push branch ${BRANCH} and open PR with ${applied.length} entries`);
+    // Revert any file edits we made so the working tree doesn't leak into the next step.
+    try { git(['checkout', '--', '.']); } catch { /* best effort */ }
+    process.exit(0);
+  }
+
+  commitAndPushSelf(applied.length);
+  const prUrl = openSelfPr(applied);
+  log(`PR opened: ${prUrl}`);
+
+  // Back-link on each source issue so triage-ers can follow the fix.
+  for (const entry of applied) {
+    commentOnSourceIssue(entry.repo, entry.issueNumber, prUrl);
+  }
+
+  process.exit(0);
+})();

--- a/scripts/autofix-phpcbf.js
+++ b/scripts/autofix-phpcbf.js
@@ -1,0 +1,309 @@
+#!/usr/bin/env node
+/**
+ * Phase 5c flow A — monthly phpcbf auto-fix PRs.
+ *
+ * For each target repo marked `autofix.phpcs: true` in
+ * discovered-targets.json:
+ *   1. Skip if an open autofix PR already exists (prevents stacking).
+ *   2. Skip if the same-month branch already exists on remote.
+ *   3. Clone the target (shallow, depth 10 — enough for phpcbf).
+ *   4. Run phpcbf with the WPCS ruleset.
+ *   5. If diff non-empty: branch, commit, push, open PR, label.
+ *
+ * Idempotency: branch name is `repo-health/autofix-phpcbf-<YYYY-MM>`
+ * so a single re-run inside the same month is a no-op.
+ *
+ * Environment:
+ *   GH_TOKEN            App token (has ruleset bypass + repo write)
+ *   DRY_RUN             "true" to log intent without pushing / opening PRs
+ *   TARGETS_JSON        path to discovered-targets.json
+ *   PHPCBF_STANDARD     phpcs standard to pass to phpcbf (default WordPress)
+ *
+ * Exit code: 0 regardless of per-repo outcomes. A single bad repo
+ * shouldn't fail the whole monthly run.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const os = require('os');
+
+const TOKEN = process.env.GH_TOKEN || process.env.GITHUB_TOKEN || '';
+const DRY_RUN = String(process.env.DRY_RUN || '').toLowerCase() === 'true';
+const TARGETS_JSON = process.env.TARGETS_JSON || 'discovered-targets.json';
+const STANDARD = process.env.PHPCBF_STANDARD || 'WordPress';
+const ORG = process.env.ORG || 'Kilowott-labs';
+
+if (!TOKEN) {
+  console.error('GH_TOKEN / GITHUB_TOKEN required (App token preferred).');
+  process.exit(1);
+}
+if (!fs.existsSync(TARGETS_JSON)) {
+  console.error(`Targets file ${TARGETS_JSON} not found — run discover.js first.`);
+  process.exit(1);
+}
+
+const MONTH = new Date().toISOString().slice(0, 7); // YYYY-MM
+const BRANCH = `repo-health/autofix-phpcbf-${MONTH}`;
+const BRANCH_PATTERN = 'repo-health/autofix-phpcbf-';
+
+function log(line) {
+  console.log(`[autofix-phpcbf] ${line}`);
+}
+
+// Array-form runners — no shell interpretation of dynamic strings.
+function git(args, opts = {}) {
+  return execFileSync('git', args, {
+    stdio: 'inherit', encoding: 'utf8', ...opts,
+  });
+}
+
+function gh(args) {
+  return execFileSync('gh', args, {
+    encoding: 'utf8',
+    env: { ...process.env, GH_TOKEN: TOKEN, GITHUB_TOKEN: TOKEN },
+  });
+}
+
+// Authenticated git — injects the token via per-command `http.extraheader`
+// rather than embedding it in the remote URL. This avoids writing the
+// token to .git/config, which would persist on disk after the run and
+// leak if the workspace is snapshotted.
+// (Token still appears in argv visible to same-uid processes on the
+// runner, which is an accepted exposure on ephemeral runners.)
+function gitAuth(args, opts = {}) {
+  return git(
+    ['-c', `http.extraheader=Authorization: Bearer ${TOKEN}`, ...args],
+    opts,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Eligibility — only process repos with autofix.phpcs === true
+// ---------------------------------------------------------------------------
+function loadEligibleRepos() {
+  const raw = JSON.parse(fs.readFileSync(TARGETS_JSON, 'utf8'));
+  const out = [];
+  for (const repo of (raw.repos || [])) {
+    const eligible = repo.autofix && repo.autofix.phpcs === true;
+    if (eligible) out.push(repo);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Idempotency — skip if a matching open PR already exists
+// ---------------------------------------------------------------------------
+function existingAutofixPR(repo) {
+  try {
+    const body = gh([
+      'pr', 'list',
+      '--repo', `${ORG}/${repo}`,
+      '--state', 'open',
+      '--search', `head:${BRANCH_PATTERN} in:title [autofix]`,
+      '--json', 'number,title,headRefName,url',
+    ]);
+    const arr = JSON.parse(body || '[]');
+    // gh's --search doesn't always match exactly — filter by head prefix locally.
+    return arr.find(pr => String(pr.headRefName || '').startsWith(BRANCH_PATTERN)) || null;
+  } catch (err) {
+    log(`${repo}: pr list failed (${err.message.slice(0, 120)}) — assuming none open`);
+    return null;
+  }
+}
+
+function existingAutofixBranch(repo) {
+  try {
+    const body = gh([
+      'api', `/repos/${ORG}/${repo}/branches/${encodeURIComponent(BRANCH)}`,
+    ]);
+    return Boolean(body && body.trim());
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-repo workflow
+// ---------------------------------------------------------------------------
+function cloneTarget(repo, workDir) {
+  // Plain https URL — no token in the URL means no token persists in
+  // the cloned .git/config. Auth rides in via gitAuth's extraheader.
+  gitAuth(['clone', '--depth', '10', `https://github.com/${ORG}/${repo}.git`, workDir]);
+}
+
+function runPhpcbf(workDir) {
+  // phpcbf exits non-zero when it made changes — that's expected.
+  // Don't treat exit code as fatal.
+  try {
+    execFileSync('phpcbf', ['--standard=' + STANDARD, '--report=summary', '.'], {
+      cwd: workDir, stdio: 'inherit',
+    });
+  } catch {
+    /* non-zero = fixes made, fall through */
+  }
+}
+
+function hasDiff(workDir) {
+  const out = execFileSync('git', ['status', '--porcelain'], {
+    cwd: workDir, encoding: 'utf8',
+  });
+  return out.trim().length > 0;
+}
+
+function countFixedFiles(workDir) {
+  const out = execFileSync('git', ['status', '--porcelain'], {
+    cwd: workDir, encoding: 'utf8',
+  });
+  return out.trim().split('\n').filter(Boolean).length;
+}
+
+function commitAndPush(repo, workDir) {
+  const commitMessage =
+    `chore(autofix): phpcbf mechanical style fixes ${MONTH}\n\n` +
+    `Auto-generated by Kilowott repo-health. Mechanical PHPCS fixes\n` +
+    `(spacing, indentation, array syntax, docblocks) applied via phpcbf\n` +
+    `--standard=${STANDARD}.\n\n` +
+    `Review the diff — phpcbf is conservative but human review is\n` +
+    `important before merging into a client codebase.`;
+
+  const opts = { cwd: workDir };
+  git(['config', 'user.name',  'kilowott-repo-health-bot[bot]'],                           opts);
+  git(['config', 'user.email', 'kilowott-repo-health-bot[bot]@users.noreply.github.com'],  opts);
+  git(['checkout', '-b', BRANCH],                                                          opts);
+  git(['add', '-A'],                                                                       opts);
+  git(['commit', '-m', commitMessage],                                                     opts);
+  gitAuth(['push', 'origin', BRANCH],                                                      opts);
+}
+
+function openPullRequest(repo, fixedFileCount) {
+  const title = `[autofix] PHPCS phpcbf ${MONTH}`;
+  const body =
+`Mechanical PHPCS fixes from repo-health's weekly scan pipeline.
+
+## What changed
+phpcbf \`--standard=${STANDARD}\` ran over .php files in this repo.
+**${fixedFileCount} file${fixedFileCount === 1 ? '' : 's'} changed.**
+
+## Scope
+Only mechanical fixes: whitespace, indentation, array syntax,
+docblock formatting. No semantic changes.
+
+## Review guidance
+- Check PHP files for any functional change — there should be none.
+- Verify test suite (if any) still passes.
+- If anything looks wrong, close without merging — next month's run
+  will re-attempt with the current code.
+
+## Acknowledgment
+This PR was auto-generated by \`Kilowott Repo Health Bot\`.
+Run: ${process.env.RUN_URL || 'local run'}
+`;
+  const url = gh([
+    'pr', 'create',
+    '--repo', `${ORG}/${repo}`,
+    '--base', 'main',
+    '--head', BRANCH,
+    '--title', title,
+    '--body', body,
+    '--label', 'autofix',
+    '--label', 'phpcbf',
+  ]).trim();
+  return url;
+}
+
+function labelPr(repo, number, labels) {
+  try {
+    gh([
+      'pr', 'edit', String(number),
+      '--repo', `${ORG}/${repo}`,
+      ...labels.flatMap(l => ['--add-label', l]),
+    ]);
+  } catch (err) {
+    log(`${repo}: label add failed (${err.message.slice(0, 120)})`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+(function main() {
+  const repos = loadEligibleRepos();
+  log(`eligible repos: ${repos.length} (${repos.map(r => r.name).join(', ') || 'none'})`);
+  log(`branch name for this month: ${BRANCH}`);
+  log(`dry_run: ${DRY_RUN}`);
+
+  const summary = { skipped: [], unchanged: [], opened: [], errored: [] };
+
+  for (const repo of repos) {
+    const name = repo.name;
+    log(`--- ${name} ---`);
+
+    // Idempotency: open PR
+    const openPr = existingAutofixPR(name);
+    if (openPr) {
+      log(`${name}: open autofix PR exists (#${openPr.number}) — skipping`);
+      summary.skipped.push({ name, reason: `open PR #${openPr.number}` });
+      continue;
+    }
+
+    // Idempotency: same-month branch
+    if (existingAutofixBranch(name)) {
+      log(`${name}: branch ${BRANCH} already exists on remote — skipping`);
+      summary.skipped.push({ name, reason: `branch exists` });
+      continue;
+    }
+
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), `autofix-${name}-`));
+    try {
+      log(`${name}: cloning → ${workDir}`);
+      cloneTarget(name, workDir);
+
+      log(`${name}: running phpcbf --standard=${STANDARD}`);
+      runPhpcbf(workDir);
+
+      if (!hasDiff(workDir)) {
+        log(`${name}: no phpcbf changes`);
+        summary.unchanged.push(name);
+        continue;
+      }
+
+      const fixedCount = countFixedFiles(workDir);
+      log(`${name}: ${fixedCount} file(s) changed`);
+
+      if (DRY_RUN) {
+        log(`${name}: DRY RUN — would push branch ${BRANCH} and open PR with ${fixedCount} fixes`);
+        summary.opened.push({ name, dryRun: true, fixedCount });
+        continue;
+      }
+
+      commitAndPush(name, workDir);
+      const prUrl = openPullRequest(name, fixedCount);
+      log(`${name}: PR opened → ${prUrl}`);
+      summary.opened.push({ name, url: prUrl, fixedCount });
+    } catch (err) {
+      log(`${name}: errored — ${err.message.slice(0, 200)}`);
+      summary.errored.push({ name, error: err.message.slice(0, 200) });
+    } finally {
+      // Clean up the temp clone to keep the runner tidy.
+      try { fs.rmSync(workDir, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+  }
+
+  log('--- summary ---');
+  log(JSON.stringify({
+    eligible: repos.length,
+    opened: summary.opened.length,
+    unchanged: summary.unchanged.length,
+    skipped: summary.skipped.length,
+    errored: summary.errored.length,
+    month: MONTH,
+    dryRun: DRY_RUN,
+  }));
+  if (summary.opened.length > 0)   log('opened: '   + JSON.stringify(summary.opened));
+  if (summary.unchanged.length > 0) log('unchanged: ' + JSON.stringify(summary.unchanged));
+  if (summary.skipped.length > 0)  log('skipped: '  + JSON.stringify(summary.skipped));
+  if (summary.errored.length > 0)  log('errored: '  + JSON.stringify(summary.errored));
+
+  process.exit(0);
+})();

--- a/scripts/discover.js
+++ b/scripts/discover.js
@@ -148,6 +148,10 @@ async function listOrgRepos(org) {
       priority: ov.priority || autoPriority,
       stack: ov.stack || autoStack,
       private: repo.private,
+      // Autofix flags — per-repo opt-in, read by Phase 5c workflows
+      // (autofix-phpcbf.js / autofix-allowlist.js). Defaults to {}
+      // so downstream code can safely check `autofix.phpcs === true`.
+      autofix: ov.autofix || {},
       // Metadata for audit / debugging
       _source: {
         autoPriority,

--- a/scripts/file-issues.js
+++ b/scripts/file-issues.js
@@ -21,6 +21,7 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 const resolveAssignees = require('./assign-codeowner');
+const { fingerprint: sharedFingerprint } = require('./lib/fingerprint');
 
 const TOKEN = process.env.GITHUB_TOKEN;
 const ORG = process.env.ORG || 'Kilowott-labs';
@@ -37,28 +38,11 @@ if (!TOKEN) {
 }
 
 // ---------------------------------------------------------------------------
-// Fingerprinting — stable per-finding ID so dismissals survive re-scans
+// Fingerprinting — delegate to scripts/lib/fingerprint.js so this code,
+// aggregate.js, and autofix-allowlist.js all produce the same F-xxxxxxxx
+// IDs for the same finding. Algorithm details live in that shared module.
 // ---------------------------------------------------------------------------
-function fingerprint(finding) {
-  // Fingerprint intentionally excludes commit SHA so the same underlying leak
-  // (same rule + same file + same line) dedupes across every commit it appears
-  // in. Gitleaks reports each historical occurrence separately when walking
-  // --all; for a team-facing issue we want one entry per unique leak with a
-  // "first seen / last seen" summary instead.
-  //
-  // Includes source (scanner name) to prevent cross-scanner collisions — a
-  // PHPCS finding and a Gitleaks finding could both report "line 42" of the
-  // same file for unrelated reasons.
-  const rule = finding.RuleID || finding.ruleID || 'unknown';
-  const file = finding.File || finding.file || '';
-  const line = finding.StartLine || finding.startLine || 0;
-  const source = finding.Source || finding.source || 'gitleaks';
-  const h = crypto.createHash('sha1')
-    .update(`${source}|${rule}|${file}|${line}`)
-    .digest('hex')
-    .slice(0, 8);
-  return `F-${h}`;
-}
+const fingerprint = sharedFingerprint;
 
 // Groups N raw findings by fingerprint, returns deduped entries with
 // first/last commit metadata preserved.

--- a/scripts/lib/fingerprint.js
+++ b/scripts/lib/fingerprint.js
@@ -1,0 +1,35 @@
+/**
+ * Shared finding fingerprint — single source of truth for `F-xxxxxxxx` IDs.
+ *
+ * Previously both file-issues.js (SHA-1) and aggregate.js (SHA-256)
+ * had their own implementations, which produced DIFFERENT IDs for
+ * the same finding. Issue bodies in target repos use the SHA-1
+ * value (file-issues.js is what writes the issue text), so this
+ * module preserves that algorithm. autofix-allowlist.js parses
+ * IDs out of those issue bodies, so it must match.
+ *
+ * Exclusions:
+ *   - commit SHA is NOT in the fingerprint — the same leak across
+ *     many commits dedupes to one entry with first/last-seen meta.
+ *
+ * Inclusions:
+ *   - Source (scanner name) guards against cross-scanner collisions
+ *     where a PHPCS finding and a Gitleaks finding happen to land
+ *     on the same file:line.
+ */
+
+const crypto = require('crypto');
+
+function fingerprint(finding) {
+  const rule   = finding.RuleID    || finding.ruleID    || 'unknown';
+  const file   = finding.File      || finding.file      || '';
+  const line   = finding.StartLine || finding.startLine || 0;
+  const source = finding.Source    || finding.source    || 'gitleaks';
+  const h = crypto.createHash('sha1')
+    .update(`${source}|${rule}|${file}|${line}`)
+    .digest('hex')
+    .slice(0, 8);
+  return `F-${h}`;
+}
+
+module.exports = { fingerprint };

--- a/targets.yml
+++ b/targets.yml
@@ -27,6 +27,14 @@ overrides:
   # kw-security-plugin:
   #   priority: critical    # already critical by name match — no override needed
 
+  # Phase 5c — monthly phpcbf auto-fix PRs. Canary scope: only
+  # kw-wp-scaffold is flagged for now. Rollout to other WP repos
+  # happens after the canary's first merged PR validates the flow.
+  kw-wp-scaffold:
+    priority: high          # private + kw- prefix already gives this, explicit for clarity
+    autofix:
+      phpcs: true
+
   # Example of overriding stack when auto-detection misses something:
   # some-repo:
   #   stack: wp-theme       # repo language is PHP but it's actually a WP theme


### PR DESCRIPTION
Ships Phase 5c per design doc §5.

## What landed
- Flow A: PHPCS phpcbf auto-PRs, canary kw-wp-scaffold only
- Flow B: false-positive allowlist-PR flow
- Orchestrator: monthly cron + manual dispatch

## Canary policy
Only kw-wp-scaffold is flagged for A. Other repos skipped until
explicit rollout.

## Idempotency
Branch-name collision check prevents duplicate PRs on re-runs.
Safe to run dry_run multiple times or schedule-retrigger.

## Collateral fix (not planned for 5c)
aggregate.js previously used SHA-256 for dashboard F-IDs; file-issues.js
used SHA-1 for GitHub issue body IDs. The two diverged. Consolidated
both into scripts/lib/fingerprint.js (SHA-1). Next scan's dashboard.json
will have new F-IDs aligned with GitHub issue IDs. No external
consumers of the old dashboard F-IDs.

## Security hardening
- Token injected via `git -c http.extraheader` for clone/push;
  never written to .git/config
- All git commands with dynamic input use execFileSync array form
  (no shell interpretation)

## Sneha — please approve
Canary scope. One-step workflow edit + two new scripts + shared
fingerprint lib. Needs your click.