### PR TITLE
fix(autofix-phpcbf): Basic auth header for git clone/push

### DIFF
--- a/scripts/autofix-phpcbf.js
+++ b/scripts/autofix-phpcbf.js
@@ -69,11 +69,15 @@ function gh(args) {
 // rather than embedding it in the remote URL. This avoids writing the
 // token to .git/config, which would persist on disk after the run and
 // leak if the workspace is snapshotted.
-// (Token still appears in argv visible to same-uid processes on the
-// runner, which is an accepted exposure on ephemeral runners.)
+//
+// Git smart-HTTP expects Basic auth (not Bearer) — matches the pattern
+// actions/checkout@v4 installs. Token still appears in argv visible to
+// same-uid processes on the runner, which is an accepted exposure on
+// ephemeral runners.
+const TOKEN_BASIC = Buffer.from(`x-access-token:${TOKEN}`).toString('base64');
 function gitAuth(args, opts = {}) {
   return git(
-    ['-c', `http.extraheader=Authorization: Bearer ${TOKEN}`, ...args],
+    ['-c', `http.extraheader=Authorization: Basic ${TOKEN_BASIC}`, ...args],
     opts,
   );
 }


### PR DESCRIPTION
Hotfix — dry-run of autofix-monthly failed because git smart-HTTP
expects Basic auth, not Bearer. My earlier code used:

    http.extraheader=Authorization: Bearer <token>

which GitHub's REST API accepts but git clone/push does not.
Changed to match actions/checkout@v4's pattern:

    http.extraheader=Authorization: Basic <base64(x-access-token:<token>)>

Token still never touches .git/config, only per-command argv.

## Dry-run log showing the failure
```
kw-wp-scaffold: errored — Command failed: git -c http.extraheader=Authorization: *** clone --depth 10 https://github.com/Kilowott-labs/kw-wp-scaffold.git /tmp/autofix-kw-wp-scaffold-
```

## Validation
Re-run dry_run after merge — clone should succeed and phpcbf
should report file change count.

## Sneha — please approve
Single-file hotfix. Needs your click.