### PR TITLE
fix(autofix): ensure labels exist on target repos before gh pr create

### DIFF
--- a/scripts/autofix-allowlist.js
+++ b/scripts/autofix-allowlist.js
@@ -194,6 +194,26 @@ function existingBranch() {
   }
 }
 
+// Ensure a label exists on repo-health. gh pr create --label aborts
+// when the label is missing. --force makes the helper idempotent.
+function ensureLabel(name, color, description) {
+  try {
+    execFileSync('gh', [
+      'label', 'create', name,
+      '--repo', `${ORG}/repo-health`,
+      '--color', color,
+      '--description', description,
+      '--force',
+    ], {
+      encoding: 'utf8',
+      env: { ...process.env, GH_TOKEN: TOKEN, GITHUB_TOKEN: TOKEN },
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+  } catch (err) {
+    log(`label '${name}' ensure failed — ${err.message.slice(0, 120)}`);
+  }
+}
+
 function commitAndPushSelf(appliedCount) {
   const msg =
     `chore(autofix-allowlist): batch config updates ${MONTH}\n\n` +
@@ -347,6 +367,9 @@ function commentOnSourceIssue(repo, issueNumber, prUrl) {
   }
 
   commitAndPushSelf(applied.length);
+  // Ensure PR labels exist on repo-health before gh pr create.
+  ensureLabel('autofix',   '84CC16', 'Auto-generated fix PR from repo-health');
+  ensureLabel('allowlist', '65A30D', 'False-positive allowlist update');
   const prUrl = openSelfPr(applied);
   log(`PR opened: ${prUrl}`);
 

--- a/scripts/autofix-phpcbf.js
+++ b/scripts/autofix-phpcbf.js
@@ -127,6 +127,29 @@ function existingAutofixBranch(repo) {
   }
 }
 
+// Ensure a label exists on the target repo. `gh pr create --label X`
+// errors (and aborts PR creation) if X doesn't pre-exist. Idempotent
+// via --force: creates the label if absent, updates color/description
+// if present. Failure is logged but not fatal — PR create will still
+// try, and if it fails the whole repo is marked errored.
+function ensureLabel(repo, name, color, description) {
+  try {
+    execFileSync('gh', [
+      'label', 'create', name,
+      '--repo', `${ORG}/${repo}`,
+      '--color', color,
+      '--description', description,
+      '--force',
+    ], {
+      encoding: 'utf8',
+      env: { ...process.env, GH_TOKEN: TOKEN, GITHUB_TOKEN: TOKEN },
+      stdio: ['ignore', 'ignore', 'pipe'],
+    });
+  } catch (err) {
+    log(`${repo}: label '${name}' ensure failed — ${err.message.slice(0, 120)}`);
+  }
+}
+
 // Heal: branch exists on remote but no PR is open — typically means
 // a previous run pushed the branch then errored during PR creation.
 // Delete the branch so the current run can re-clone + re-push + PR.
@@ -304,6 +327,12 @@ function labelPr(repo, number, labels) {
       }
 
       commitAndPush(name, workDir);
+      // Ensure PR labels exist on target repo before gh pr create.
+      // Colors chosen to match the severity palette in
+      // dashboard/src/index.css (accent=lime for autofix, high=amber
+      // for the scanner-specific marker).
+      ensureLabel(name, 'autofix', '84CC16', 'Auto-generated fix PR from repo-health');
+      ensureLabel(name, 'phpcbf',  'D97706', 'PHPCS phpcbf mechanical fix');
       const prUrl = openPullRequest(name, fixedCount, baseBranch);
       log(`${name}: PR opened → ${prUrl}`);
       summary.opened.push({ name, url: prUrl, fixedCount });


### PR DESCRIPTION
Third hotfix from the 2026-04 canary real-run attempt. Label error
was the last blocker identified in the end-to-end audit.

## What changed
- scripts/autofix-phpcbf.js: ensureLabel('autofix', 'phpcbf') on
  target repo before gh pr create
- scripts/autofix-allowlist.js: ensureLabel('autofix', 'allowlist')
  on repo-health before gh pr create
- Both use `gh label create --force` → idempotent create-or-update

## Audit results (8 items + 1 new)
Covered: labels, base branch, CODEOWNERS, branch protection,
@mentions, branch naming, clone depth. One cosmetic-only item
(bot email format) deferred — requires App metadata lookup, not
blocking canary.

## Canary state post-merge
- Stranded branch on kw-wp-scaffold from prior attempt still
  exists — self-heal (from prior hotfix #32) will delete + retry
  on next workflow run
- No manual cleanup needed

## Sneha — please approve
Single-focus fix. Same pattern as #32. Two files, +52 lines.